### PR TITLE
#40 - Fix for Chrome based browsers version 111

### DIFF
--- a/openmaqs-selenium/src/main/java/io/github/openmaqs/selenium/WebDriverFactory.java
+++ b/openmaqs-selenium/src/main/java/io/github/openmaqs/selenium/WebDriverFactory.java
@@ -98,6 +98,7 @@ public class WebDriverFactory {
     chromeOptions.addArguments("--disable-web-security");
     chromeOptions.addArguments("--allow-running-insecure-content");
     chromeOptions.addArguments("--disable-extensions");
+    chromeOptions.addArguments("--remote-allow-origins=*");
 
     if (OperatingSystem.getOperatingSystem() == OperatingSystem.LINUX) {
       chromeOptions.addArguments("--no-sandbox");
@@ -130,6 +131,7 @@ public class WebDriverFactory {
     headlessChromeOptions.addArguments("--disable-extensions");
     headlessChromeOptions.addArguments("--no-sandbox");
     headlessChromeOptions.addArguments("--headless");
+    headlessChromeOptions.addArguments("--remote-allow-origins=*");
     headlessChromeOptions.addArguments(getHeadlessWindowSizeString(size));
 
     return headlessChromeOptions;
@@ -166,6 +168,7 @@ public class WebDriverFactory {
    */
   public static EdgeOptions getDefaultEdgeOptions() {
     EdgeOptions edgeOptions = new EdgeOptions();
+    edgeOptions.addArguments("--remote-allow-origins=*");
     edgeOptions.setPageLoadStrategy(PageLoadStrategy.NORMAL);
     return edgeOptions;
   }

--- a/openmaqs-selenium/src/test/java/io/github/openmaqs/selenium/WebDriverFactoryUnitTest.java
+++ b/openmaqs-selenium/src/test/java/io/github/openmaqs/selenium/WebDriverFactoryUnitTest.java
@@ -146,7 +146,6 @@ public class WebDriverFactoryUnitTest extends BaseGenericTest {
   /**
    * Tests getting the Edge driver.
    */
-  @Ignore
   @Test(groups = TestCategories.SELENIUM)
   public void getEdgeDriverTest() {
     EdgeDriver driver = null;


### PR DESCRIPTION
- Added workaround argument as a default for Chrome and Edge
- Re-enabled Edge unit test thanks to Chrome-based Edge on Ubuntu.