### PR TITLE
#45 - Added Maven dependency tree submission job

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,6 @@ on:
         default: '0.0.0'
 
 jobs:
-
   waitOld:
     name: Wait For Older Runs To Complete
     runs-on: ubuntu-latest
@@ -57,6 +56,26 @@ jobs:
       - uses: release-drafter/release-drafter@v5.23.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dependency-tree:
+    name: Maven Dependency Tree
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3.11.0
+        with:
+          distribution: zulu
+          java-version: 11
+          cache: maven
+      - name: Restore Local Maven Cache
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.m2
+          key: ${{runner.os}}-m2
+      - name: Submit Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@v3
 
   getVersion:
     name: Get package version

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -280,7 +280,7 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Deploy Release v${{ needs.getVersion.outputs.buildNumber }} to OSSRH
-        run: mvn -Drevision=${{ needs.getVersion.outputs.buildNumber }} deploy
+        run: mvn -B -e -Drevision=${{ needs.getVersion.outputs.buildNumber }} deploy
       - name: Publish GitHub release v${{ needs.getVersion.outputs.buildNumber }}
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
The job that uploads a dependency tree snapshot to the GH dependency submission API.  Only runs on push to main.